### PR TITLE
feat: extend `BaseFunction` trait

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -70,6 +70,12 @@ pub trait BaseFunction<'a> {
         }
         self
     }
+    fn set_negative_prompt(&mut self, negative_prompt: &str) -> &mut Self {
+        {
+            self.base().negative_prompt = negative_prompt.to_string();
+        }
+        self
+    }
     fn set_output_path(&mut self, output_path: &str) -> &mut Self {
         {
             self.base().output_path = output_path.to_string();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -70,9 +70,9 @@ pub trait BaseFunction<'a> {
         }
         self
     }
-    fn set_negative_prompt(&mut self, negative_prompt: &str) -> &mut Self {
+    fn set_negative_prompt(&mut self, negative_prompt: impl Into<String>) -> &mut Self {
         {
-            self.base().negative_prompt = negative_prompt.to_string();
+            self.base().negative_prompt = negative_prompt.into();
         }
         self
     }


### PR DESCRIPTION
In this PR, introduce `set_negative_prompt` func into `BaseFunction` trait. The purpose of the function is to set `negative prompt`.