### PR TITLE
feat: support flux.1-schnell model

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,25 @@ name: Build Rust Crate
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - dev
+      - main
+      - release-*
+      - feat-*
+      - ci-*
+      - refactor-*
+      - fix-*
+      - test-*
   pull_request:
-    branches: [ main ]
+    branches:
+      - dev
+      - main
+      - release-*
+      - feat-*
+      - ci-*
+      - refactor-*
+      - fix-*
+      - test-*
 
 env:
   CARGO_TERM_COLOR: always

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -3,8 +3,66 @@
 version = 3
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "wasmedge_stable_diffusion"
 version = "0.2.0"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "wasmedge_stable_diffusion_example"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,5 +3,63 @@
 version = 3
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "wasmedge_stable_diffusion"
 version = "0.2.0"
+dependencies = [
+ "thiserror",
+]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,3 +10,4 @@ description = "A Rust library for using stable diffusion functions when the Wasi
 
 
 [dependencies]
+thiserror = "1"

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+/// Error types for the Llama Core library.
+#[derive(Error, Debug)]
+pub enum SDError {
+    /// Errors in General operation.
+    #[error("{0}")]
+    Operation(String),
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -403,7 +403,7 @@ impl SDBuidler {
         let path = path.as_ref().to_str().ok_or_else(|| {
             SDError::Operation("The path to the vae file is not valid unicode.".into())
         })?;
-        self.sd.t5xxl_path = path.into();
+        self.sd.vae_path = path.into();
         Ok(self)
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -442,4 +442,8 @@ impl SDBuidler {
         self.sd.n_threads = n_threads;
         self
     }
+
+    pub fn build(self) -> StableDiffusion {
+        self.sd
+    }
 }

--- a/rust/src/stable_diffusion_interface.rs
+++ b/rust/src/stable_diffusion_interface.rs
@@ -52,7 +52,7 @@ impl fmt::Display for WasmedgeSdErrno {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum SdTypeT {
     SdTypeF32 = 0,
     SdTypeF16 = 1,
@@ -90,12 +90,12 @@ pub enum SdTypeT {
     SdTypeQ4088 = 33,
     SdTypeCount = 34,
 }
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum RngTypeT {
     StdDefaultRng = 0,
     CUDARng = 1,
 }
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum SampleMethodT {
     EULERA = 0,
     EULER = 1,
@@ -108,7 +108,7 @@ pub enum SampleMethodT {
     IPNDMV = 8,
     LCM = 9,
 }
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum ScheduleT {
     DEFAULT = 0,
     DISCRETE = 1,
@@ -117,6 +117,7 @@ pub enum ScheduleT {
     AYS = 4,
     GITS = 5,
 }
+#[derive(Debug)]
 pub enum ImageType<'a> {
     Path(&'a str),
 }


### PR DESCRIPTION
Major changes:

- Introduce `SDBuidler` to create `StableDiffusion` instances.
- Introduce `new_with_standalone_model` method into `StableDiffusion`. The method is used to create a `StableDiffustion` instance from a standalone diffusion model.